### PR TITLE
gooood script is bad, hard-codes links. ew

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -9,7 +9,6 @@
   "devexcuse.coffee",
   "dice.coffee",
   "directions.coffee",
-  "goooood.coffee",
   "isup.coffee",
   "manatee.coffee",
   "meme_generator.coffee",


### PR DESCRIPTION
Removed goood script from hubot-scripts.json.
